### PR TITLE
Change messages according to the existence of open issues that are not set to notify.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ const notice = new GithubIssuesNotice({
       .getProperty('SLACK_ACCESS_TOKEN'),
     username: 'GitHub Issues Notice',
     textSuffix: ` -- <${sheetUrl}|Settings> | <${projectUrl}|About>`,
-    textEmpty: 'Wow, No open issues! We did it! :tada:',
+    textEmpty: 'Wow, No issues to notify! We did it! :tada:',
     textDefault: 'Check it out :point_down:'
   },
   spreadsheets: {


### PR DESCRIPTION
Hi @linyows !

I found that when there are open issues not covered by notification, we notified as "Wow, No open issues".  I think it would be better to change the message, but how about you?